### PR TITLE
Fix dependency name in import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Pre-built libraries are available on [NPM](https://www.npmjs.com/package/com.git
     "com.github.asus4.onnxruntime.unity": "0.1.10",
     "com.github.asus4.onnxruntime.win-x64-gpu": "0.1.10",
     "com.github.asus4.onnxruntime.linux-x64-gpu": "0.1.10",
-    "com.github.asus4.onnxruntime.extensions": "0.1.10",
+    "com.github.asus4.onnxruntime-extensions": "0.1.10",
     ... other dependencies
   }
 ```


### PR DESCRIPTION
The dependency name for the extension seems to be with "-": https://www.npmjs.com/package/com.github.asus4.onnxruntime?activeTab=dependents