### PR TITLE
Allow importing *.onnx files only when sentis is not installed

### DIFF
--- a/com.github.asus4.onnxruntime.unity/Editor/OrtImporter.cs
+++ b/com.github.asus4.onnxruntime.unity/Editor/OrtImporter.cs
@@ -5,9 +5,15 @@ using UnityEditor.AssetImporters;
 namespace Microsoft.ML.OnnxRuntime.Unity.Editor
 {
     /// <summary>
-    /// Imports *.ort file as OrtAsset
+    /// Imports *.ort or *.onnx file as OrtAsset
+    /// 
+    /// *.onnx can be imported only when com.unity.sentis is NOT installed
     /// </summary>
+#if ORT_UNITY_SENTIS_ENABLED
     [ScriptedImporter(1, "ort")]
+#else // !ORT_UNITY_SENTIS_ENABLED
+    [ScriptedImporter(1, new[] { "ort", "onnx" })]
+#endif // !ORT_UNITY_SENTIS_ENABLED
     public class OrtImporter : ScriptedImporter
     {
         public override void OnImportAsset(AssetImportContext ctx)

--- a/com.github.asus4.onnxruntime.unity/Editor/com.github.asus4.onnxruntime.unity.Editor.asmdef
+++ b/com.github.asus4.onnxruntime.unity/Editor/com.github.asus4.onnxruntime.unity.Editor.asmdef
@@ -13,6 +13,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.sentis",
+            "expression": "",
+            "define": "ORT_UNITY_SENTIS_ENABLED"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/com.github.asus4.onnxruntime.unity/Runtime/OrtAsset.cs
+++ b/com.github.asus4.onnxruntime.unity/Runtime/OrtAsset.cs
@@ -3,7 +3,9 @@ using UnityEngine;
 namespace Microsoft.ML.OnnxRuntime.Unity
 {
     /// <summary>
-    /// Simple asset to hold *.ort file as byte array
+    /// Simple asset to hold *.ort and *.onnx file as byte array
+    /// 
+    /// *.onnx can be imported only when com.unity.sentis is NOT installed
     /// </summary>
     public class OrtAsset : ScriptableObject
     {


### PR DESCRIPTION
Allows importing Onnx files as OrtAsset, when Unity sentis is not installed.
