### PR TITLE
Revert big NPM package

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -40,8 +40,8 @@ jobs:
           publish_npm com.github.asus4.onnxruntime
           publish_npm com.github.asus4.onnxruntime.unity
           publish_npm com.github.asus4.onnxruntime-extensions
-          publish_npm com.github.asus4.onnxruntime.linux-x64-gpu
-          publish_npm com.github.asus4.onnxruntime.win-x64-gpu
+          # publish_npm com.github.asus4.onnxruntime.linux-x64-gpu
+          # publish_npm com.github.asus4.onnxruntime.win-x64-gpu
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       # Upload packages to GitHub release page

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ Pre-built libraries are available on [NPM](https://www.npmjs.com/package/com.git
     }
   ]
   "dependencies": {
-    "com.github.asus4.onnxruntime": "0.3.4",
-    "com.github.asus4.onnxruntime.unity": "0.3.4",
-    "com.github.asus4.onnxruntime.win-x64-gpu": "0.3.4",
-    "com.github.asus4.onnxruntime-extensions": "0.3.4",
+    "com.github.asus4.onnxruntime": "0.3.5",
+    "com.github.asus4.onnxruntime.unity": "0.3.5",
+    "com.github.asus4.onnxruntime.win-x64-gpu": "0.3.5",
+    "com.github.asus4.onnxruntime-extensions": "0.3.5",
     ... other dependencies
   }
 ```

--- a/com.github.asus4.onnxruntime-extensions/package.json
+++ b/com.github.asus4.onnxruntime-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.github.asus4.onnxruntime-extensions",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "displayName": "ONNX Runtime Extensions",
   "description": "ONNX Runtime Extensions for Unity",
   "keywords": [
@@ -10,7 +10,7 @@
   "unity": "2022.3",
   "unityRelease": "0f1",
   "dependencies": {
-    "com.github.asus4.onnxruntime": "0.3.4"
+    "com.github.asus4.onnxruntime": "0.3.5"
   },
   "repository": {
     "type": "git",

--- a/com.github.asus4.onnxruntime-genai/package.json
+++ b/com.github.asus4.onnxruntime-genai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.github.asus4.onnxruntime-genai",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "displayName": "ONNX Runtime GenAI",
   "description": "ONNX Runtime Generative AI for Unity",
   "keywords": [
@@ -10,7 +10,7 @@
   "unity": "2022.3",
   "unityRelease": "0f1",
   "dependencies": {
-    "com.github.asus4.onnxruntime": "0.3.4"
+    "com.github.asus4.onnxruntime": "0.3.5"
   },
   "repository": {
     "type": "git",

--- a/com.github.asus4.onnxruntime.linux-x64-gpu/package.json
+++ b/com.github.asus4.onnxruntime.linux-x64-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.github.asus4.onnxruntime.linux-x64-gpu",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "displayName": "ONNX Runtime - Linux x64 GPU",
   "description": "ONNX Runtime for Unity - Linux x64 GPU Provider",
   "keywords": [
@@ -10,7 +10,7 @@
   "unity": "2022.3",
   "unityRelease": "0f1",
   "dependencies": {
-    "com.github.asus4.onnxruntime": "0.3.4"
+    "com.github.asus4.onnxruntime": "0.3.5"
   },
   "repository": {
     "type": "git",

--- a/com.github.asus4.onnxruntime.unity/package.json
+++ b/com.github.asus4.onnxruntime.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.github.asus4.onnxruntime.unity",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "displayName": "ONNX Runtime Unity Utilities",
   "description": "ONNX Runtime Utilities for Unity",
   "keywords": [
@@ -10,7 +10,7 @@
   "unity": "2022.3",
   "unityRelease": "0f1",
   "dependencies": {
-    "com.github.asus4.onnxruntime": "0.3.4"
+    "com.github.asus4.onnxruntime": "0.3.5"
   },
   "repository": {
     "type": "git",

--- a/com.github.asus4.onnxruntime.win-x64-gpu/package.json
+++ b/com.github.asus4.onnxruntime.win-x64-gpu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.github.asus4.onnxruntime.win-x64-gpu",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "displayName": "ONNX Runtime - Windows x64 GPU",
   "description": "ONNX Runtime for Unity - Windows x64 GPU Provider",
   "keywords": [
@@ -10,7 +10,7 @@
   "unity": "2022.3",
   "unityRelease": "0f1",
   "dependencies": {
-    "com.github.asus4.onnxruntime": "0.3.4"
+    "com.github.asus4.onnxruntime": "0.3.5"
   },
   "repository": {
     "type": "git",

--- a/com.github.asus4.onnxruntime/package.json
+++ b/com.github.asus4.onnxruntime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.github.asus4.onnxruntime",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "displayName": "ONNX Runtime",
   "description": "ONNX Runtime Plugin for Unity",
   "keywords": [


### PR DESCRIPTION
This PR reverts changes in #60 and stops publishing oversized packages again. 

See the [CI Log](https://github.com/asus4/onnxruntime-unity/actions/runs/14246565700/job/39928947035#step:6:334) for more detail:

```log
npm notice unpacked size: 343.7 MB
npm notice total files: 15
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access
npm error code E413
npm error 413 Payload Too Large - PUT https://registry.npmjs.org/com.github.asus4.onnxruntime.linux-x64-gpu - Payload Too Large
```

